### PR TITLE
Add releases with linked Nindows library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Nindows_dbg
+# Dreamcast's Nindows Debug
 
 Nindows is a Dreamcast "Windows-like" debugging GUI system used by developers using Ninja Library.
 It comes with a number of functions and built-in features such as system metrics, Texture viewer, devices info, Ninja models memory usage.
@@ -6,16 +6,119 @@ In addition, developers could integrate their own Debug menus inside a "User" su
 
 Several prototypes/commercially released games still have Nindows debugging environment hidden or disabled. For those attempting to play with those features, reverse engineer or modify said games, Re-enabling Nindows can be a game changer!
 
-Dreamcast's Nindows Debug - Supported Games
+## Supported Games
 
-Crimison OX (base)
-Grandia II (Untested)
-Vermillion Desert (base + User)
-Scud Race Dreamcast SET 2 tech demo (base)
-Sonic Shuffle Jan 11 2001 -Prototype (base + User)
-Space Channel 5 prototype v0.900 (base)
-Space Channel 5 (base / disabled)
-Skies ofArcadia V0.830 - Prototype (base)
-Maken X Feb 9 2000 - Prototype (base + User)
-Maken X (base + User)
-Tower of Babel Tech Demo (base)
+Title                                | User Menu
+------------------------------------ | -------------------
+Crimison OX                          | Base
+Grandia II                           | Untested
+Vermillion Desert                    | Base + User
+Scud Race Dreamcast SET 2 tech demo  | Base
+Sonic Shuffle Jan 11 2001 -Prototype | Base + User
+Space Channel 5 prototype v0.900     | Base
+Space Channel 5                      | Base / disabled
+Skies ofArcadia V0.830 - Prototype   | Base
+Maken X Feb 9 2000 - Prototype       | Base + User
+Maken X                              | Base + User
+Tower of Babel Tech Demo             | Base
+
+
+## Releases with linked Nindows library
+The following releases were identified by searching for the Nindows version string in the [Dreamcast Redump Extracted Data](https://github.com/lhsazevedo/dc-redump-extracted-data) v1 project
+
+Release                                                                             | Nindows Build
+----------------------------------------------------------------------------------- | -------------------------------------------------
+90 Minutes - Sega Championship Football (Europe) (En,Fr,De,Es,It)                   | Nindows2 Ver 2.12 Build:Mar 14 2001 16:29:51
+Air (Japan) (Rev A)                                                                 | Nindows Ver 01500090 Build:Feb 23 2000 16:32:37
+Akihabara Dennou-gumi Pata Pies! (Japan)                                            | Nindows Ver 01000074 Build:Mar 02 1999 20:53:52
+Animastar (Japan)                                                                   | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Atsumare! Guru Guru Onsen BB (Japan)                                                | Nindows Ver 01000077 Build:May 10 1999 16:28:59
+Atsumare! Guru Guru Onsen (Japan)                                                   | Nindows Ver 01000077 Build:May 10 1999 16:28:59
+Atsumare! Guru Guru Onsen (Japan) (Demo 1)                                          | Nindows Ver 01000077 Build:May 10 1999 16:28:59
+Atsumare! Guru Guru Onsen (Japan) (Demo 2)                                          | Nindows Ver 01000077 Build:May 10 1999 16:28:59
+BikkuriMan 2000 - Viva! Festiva! (Japan)                                            | Nindows Ver 01000078 Build:Jul 05 1999 19:57:20
+Blue-Sky-Blue[s] - Sora o Mau Tsubasa (Japan)                                       | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Bokomu no Tatsujin (Japan)                                                          | Nindows2 Ver 2.12 Build:Mar 14 2001 16:29:51
+Boku to, Bokura no Natsu (Japan)                                                    | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Canvas - Sepia Iro no Motif (Japan)                                                 | Nindows Ver 01500090 Build:Feb 23 2000 16:32:37
+Climax Landers - Motte ke! Minige Campaign (Japan)                                  | Nindows Ver 01000074 Build:Mar 02 1999 20:53:52
+Close To - Inori no Oka (Japan)                                                     | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Death Crimson 2 (Japan)                                                             | Nindows Ver 01000078 Build:Jul 05 1999 19:57:20
+Death Crimson OX (Japan)                                                            | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Death Crimson OX (USA)                                                              | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Doguu Senki - Haou (Japan)                                                          | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Elysion - Eien no Sanctuary (Japan)                                                 | Nindows Ver 01500090 Build:Feb 23 2000 16:32:37
+Erde - Nezu no Ki no Shita de (Japan)                                               | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Ever 17 - The Out of Infinity (Japan)                                               | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Ever 17 - The Out of Infinity - Premium Edition (Japan)                             | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Fur Fighters + Dead or Alive 2 (Europe) (Demo)                                      | Nindows Ver 01000078 Build:Jul 05 1999 19:57:20
+Grandia II (Europe)                                                                 | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Grandia II (Japan)                                                                  | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Grandia II (Japan) (Tentou-you Demo)                                                | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Grandia II (USA)                                                                    | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Iris (Japan)                                                                        | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Jinsei Game for Dreamcast (Japan)                                                   | Nindows Ver 01000078 Build:Jul 05 1999 19:57:20
+J.League Pro Soccer Club o Tsukurou! (Japan)                                        | Nindows Ver 01000074 Build:Mar 02 1999 20:53:52
+J.League Pro Soccer Club o Tsukurou! (Japan)                                        | Nindows Ver 01000074 Build:Mar 02 1999 20:53:52
+J.League Pro Soccer Club o Tsukurou! Tokusei o Tanoshimi File Download Disc (Japan) | Nindows Ver 01000074 Build:Mar 02 1999 20:53:52
+J.League Pro Soccer Club o Tsukurou! Tokusei o Tanoshimi File Download Disc (Japan) | Nindows Ver 01000074 Build:Mar 02 1999 20:53:52
+J.League Spectacle Soccer (Japan)                                                   | Nindows2 Ver 2.12 Build:Mar 14 2001 16:29:51
+Kanon (Japan)                                                                       | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+King of Fighters '99, The - Evolution (Japan)                                       | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+King of Fighters, The - Dream Match 1999 (Japan) (En,Ja,Es,Pt)                      | Nindows Ver 01000074 Build:Mar 02 1999 20:53:52
+King of Fighters, The - Dream Match 1999 (USA) (En,Ja,Es,Pt)                        | Nindows Ver 01000074 Build:Mar 02 1999 20:53:52
+King of Fighters, The - Evolution (USA) (En,Ja,Es,Pt)                               | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Maken X (Europe) (En,Fr,De,Es)                                                      | Nindows Ver 01000078 Build:Jul 05 1999 19:57:20
+Maken X (Japan)                                                                     | Nindows Ver 01000078 Build:Jul 05 1999 19:57:20
+Maken X (USA)                                                                       | Nindows Ver 01000078 Build:Jul 05 1999 19:57:20
+Memories Off 2nd (Japan)                                                            | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Memories Off 2nd - Promotion Disc (Japan)                                           | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Memories Off Complete (Japan)                                                       | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Mercurius Pretty - End of the Century (Japan)                                       | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Milky Season (Japan)                                                                | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Musapey's Choco Marker (Japan)                                                      | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+My Merry Maybe (Japan) (Disc 1)                                                     | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+My Merry Maybe (Japan) (Disc 2)                                                     | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+My Merry May (Japan)                                                                | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Panzer Front (Japan) (En,Ja)                                                        | Nindows Ver 01000077 Build:May 10 1999 16:28:59
+Pia Carrot e Youkoso!! 2.5 (Japan) (Disc 1) (Pia Carrot e Youkoso!! 2)              | Nindows2 Ver 2.12 Build:Mar 14 2001 16:29:51
+Pia Carrot e Youkoso!! 2.5 (Japan) (Disc 2) (Pia Carrot e Youkoso!! 2.2)            | Nindows2 Ver 2.12 Build:Mar 14 2001 16:29:51
+Pizzicato Polka - Ensa Gen'ya (Japan)                                               | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Psychic Force 2012 (Europe)                                                         | Nindows Ver 0x01000072 Build:Nov 30 1998 17:42:53
+Psychic Force 2012 (Japan)                                                          | Nindows Ver 0x01000072 Build:Nov 30 1998 17:42:53
+Psychic Force 2012 (Japan) (Taikenban)                                              | Nindows Ver 0x01000072 Build:Nov 30 1998 17:42:53
+Psychic Force 2012 (USA)                                                            | Nindows Ver 0x01000072 Build:Nov 30 1998 17:42:53
+Rainbow Cotton (Japan)                                                              | Nindows Ver 01000078 Build:Jul 05 1999 19:57:20
+Remember 11 - The Age of Infinity - Promotion Disc (Japan)                          | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Ring, The (Japan)                                                                   | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Ring, The - Terror's Realm (USA)                                                    | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Roommate Novel - Satou Yuka (Japan)                                                 | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Run=Dim as Black Soul (Japan)                                                       | Nindows2 Ver 2.12 Build:Mar 14 2001 16:29:51
+Saka Tsuku Tokudai-gou 2 - J.League Pro Soccer Club o Tsukurou! (Japan)             | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Saka Tsuku Tokudai-gou - J.League Pro Soccer Club o Tsukurou! (Japan)               | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Saka Tsuku Tokudai-gou - J.League Pro Soccer Club o Tsukurou! (Japan) (Rev A)       | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Sega GT (Europe) (En,Fr,De,Es)                                                      | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Sega GT - Homologation Special (Japan)                                              | Nindows Ver 01000078 Build:Jul 05 1999 19:57:20
+Sega GT - Homologation Special (Japan) (Taikenban)                                  | Nindows Ver 01000078 Build:Jul 05 1999 19:57:20
+Sega GT (USA)                                                                       | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Seireiki Rayblade (Japan)                                                           | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Seireiki Rayblade (Japan) (Video ROM)                                               | Nindows Ver 01000078 Build:Jul 05 1999 19:57:20
+Sentimental Graffiti 2 (Japan) (Disc 1)                                             | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Sentimental Graffiti 2 (Japan) (Disc 2)                                             | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Sentimental Graffiti - Yakusoku (Japan)                                             | Nindows Ver 01500090 Build:Feb 23 2000 16:32:37
+Shikigami no Shiro II (Japan)                                                       | Nindows2 Ver 2.12 Build:Mar 14 2001 16:29:51
+Shin Honkaku Hanafuda (Japan)                                                       | Nindows Ver 01000074 Build:Mar 02 1999 20:53:52
+Sister Princess - Premium Edition (Japan) (Disc 1)                                  | Nindows2 Ver 2.12 Build:Mar 14 2001 16:29:51
+Sister Princess - Premium Edition (Japan) (Disc 2)                                  | Nindows2 Ver 2.12 Build:Mar 14 2001 16:29:51
+Space Channel 5 (Europe) (En,Fr,De,Es) (Beta) (2000-08-10)                          | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Space Channel 5 (Europe) (En,Fr,De,Es)                                              | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Space Channel 5 (Japan)                                                             | Nindows Ver 01000078 Build:Jul 05 1999 19:57:20
+Space Channel 5 (Japan) (Taikenban)                                                 | Nindows Ver 01000078 Build:Jul 05 1999 19:57:20
+Space Channel 5 (USA)                                                               | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Suigetsu - Mayoigokoro (Japan) (Disc 1)                                             | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Suigetsu - Mayoigokoro (Japan) (Disc 2)                                             | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Tentama - 1st Sunny Side (Japan)                                                    | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Utau - Tumbling Dice (Japan)                                                        | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26
+Vermilion Desert (Japan)                                                            | Nindows Ver 01000074 Build:Mar 02 1999 20:53:52
+Yume Baken '99 - Internet (Japan)                                                   | Nindows Ver 01000077 Build:May 10 1999 16:28:59
+Yume no Tsubasa - Fate of Heart (Japan)                                             | Nindows Ver 01000079 Build:Nov 30 1999 12:08:26


### PR DESCRIPTION
Add releases identified by searching for the Nindows version string in the [Dreamcast Redump Extracted Data](https://github.com/lhsazevedo/dc-redump-extracted-data) project.

Additionally, uses the GitHub Markdown Table markup:
![image](https://github.com/user-attachments/assets/75de9fff-ecb3-4cd4-9a84-0c62361a4fdd)
